### PR TITLE
Make Header variables public

### DIFF
--- a/Sources/YouTubeKit/HeadersList.swift
+++ b/Sources/YouTubeKit/HeadersList.swift
@@ -109,10 +109,10 @@ public struct HeadersList: Codable {
         }
         
         /// Name of the header.
-        var name: String
+        public var name: String
         
         /// Content of the header.
-        var content: String
+        public var content: String
     }
 
     /// The body is usually splitted in multiple parts where a dynamic string has to be placed, adding a ``AddQueryInfo`` lets you specify what to place between those parts of body and if it should encode it or not.


### PR DESCRIPTION
Made Header variables public so the headers list can be filtered (e.g. `headers.filter { $0.name != "Authorization" }`).